### PR TITLE
[Fix] update employees migration

### DIFF
--- a/supabase/migrations/20250612063831_create_employees_table.sql
+++ b/supabase/migrations/20250612063831_create_employees_table.sql
@@ -4,6 +4,5 @@ create table employees
     as identity,
   name text,
   email text,
-  created_at timestamptz default now
-    ()
+  created_at timestamptz default now()
 );


### PR DESCRIPTION
## Summary
- fix employees table migration to use `default now()`

## Testing Done
- `flake8`
- `pytest tests/` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516ac3770c832b9d28a26af32a67a6